### PR TITLE
Paint text blocks with a gradient

### DIFF
--- a/SandboxDriver/SandboxDriver.cs
+++ b/SandboxDriver/SandboxDriver.cs
@@ -11,7 +11,7 @@ namespace SandboxDriver
             FontMapper.Default = new SandboxFontMapper();
         }
 
-        public int ContentModeCount = 14;
+        public int ContentModeCount = 15;
         public int ContentMode = 0;
         public TextDirection BaseDirection = TextDirection.LTR;
         public TextAlignment TextAlignment = TextAlignment.Auto;
@@ -79,8 +79,12 @@ namespace SandboxDriver
             shadowEffect.Width += 2 * 0.25f;
             styleShadow.AddEffect(shadowEffect);
 
-            var outlineEffect = TextEffect.Outline(new SKColor(0xFFFF0000), 1);
+            var outlineEffect = TextEffect.Outline(SKColors.Black, 4);
             styleShadow.AddEffect(outlineEffect);
+
+            var styleHeadingWithEffects = styleHeading.Modify();
+            styleHeadingWithEffects.AddEffect(shadowEffect);
+            styleHeadingWithEffects.AddEffect(outlineEffect);
 
             _textBlock.Clear();
             _textBlock.MaxWidth = width;
@@ -88,6 +92,8 @@ namespace SandboxDriver
 
             _textBlock.BaseDirection = BaseDirection;
             _textBlock.Alignment = TextAlignment;
+
+            TextGradient blockGradient = null;
 
             switch (ContentMode)
             {
@@ -239,6 +245,18 @@ namespace SandboxDriver
                     //_textBlock.AddText("Password \nAnother \n", stylePassword);
                     _textBlock.AddText("Hello World\u2029", styleNormal);
                     break;
+
+                case 14:
+                    _textBlock.AddText("Hello, text gradient\nHello, text gradient\n🌐🍪🍕🚀\nHello, text gradient\nHello, text gradient\n", styleHeadingWithEffects);
+                    blockGradient = TextGradient.Linear(new SKColor[]
+                    {
+                        SKColors.DodgerBlue,
+                        SKColors.Salmon,
+                        SKColors.GreenYellow
+                    }, null, 45);
+
+                    break;
+
             }
 
             var sw = new Stopwatch();
@@ -252,6 +270,7 @@ namespace SandboxDriver
                 Hinting = Hinting,
                 Edging = Edging,
                 SubpixelPositioning = SubpixelPositioning,
+                TextGradient = blockGradient
             };
 
             HitTestResult? htr = null;

--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -725,6 +725,7 @@ namespace Topten.RichTextKit
             {
                 // Setup SKPaint
                 paint.Color = Style.UnderlineColor ?? Style.TextColor;
+                paint.Shader = ctx.Shader;
 
                 var glyphVOffset = CreateTextBlob(ctx);
 

--- a/Topten.RichTextKit/PaintTextContext.cs
+++ b/Topten.RichTextKit/PaintTextContext.cs
@@ -49,5 +49,6 @@ namespace Topten.RichTextKit
         public SKPaint PaintSelectionHandle;
         public float SelectionHandleScale = 1.0f;
         public TextPaintOptions Options;
+        public SKShader Shader;
     }
 }

--- a/Topten.RichTextKit/TextBlock.cs
+++ b/Topten.RichTextKit/TextBlock.cs
@@ -365,6 +365,8 @@ namespace Topten.RichTextKit
                 Options = options,
             };
 
+            ctx.Shader = options.TextGradient?.CreateShader( MeasuredWidth, MeasuredHeight, MeasuredPadding.Left );
+
             // Prepare selection
             if (options.Selection.HasValue)
             {
@@ -406,6 +408,7 @@ namespace Topten.RichTextKit
 
             // Clean up
             ctx.PaintSelectionBackground?.Dispose();
+            ctx.Shader?.Dispose();
         }
 
         /// <summary>

--- a/Topten.RichTextKit/TextGradient.cs
+++ b/Topten.RichTextKit/TextGradient.cs
@@ -95,8 +95,8 @@ namespace Topten.RichTextKit
                         break;
                     case RadialSizeMode.FarthestCorner:
                         var furthestCorner = new SKPoint[] { tl, tr, br, bl }.OrderByDescending(x => x.Length).First();
-                        scaleX = furthestCorner.X / width;
-                        scaleY = furthestCorner.Y / height;
+                        scaleX = furthestCorner.X / (width * .71f);
+                        scaleY = furthestCorner.Y / (height * .71f);
                         break;
                     case RadialSizeMode.ClosestSide:
                         scaleX = Math.Min(left, right) / width;
@@ -104,8 +104,8 @@ namespace Topten.RichTextKit
                         break;
                     case RadialSizeMode.ClosestCorner:
                         var closestCorner = new SKPoint[] { tl, tr, br, bl }.OrderBy( x => x.Length ).First();
-                        scaleX = closestCorner.X / width;
-                        scaleY = closestCorner.Y / height;
+                        scaleX = closestCorner.X / (width * .71f);
+                        scaleY = closestCorner.Y / (height * .71f);
                         break;
                 }
 

--- a/Topten.RichTextKit/TextGradient.cs
+++ b/Topten.RichTextKit/TextGradient.cs
@@ -71,7 +71,9 @@ namespace Topten.RichTextKit
 
             if(GradientType == GradientType.Radial)
             {
-                return SKShader.CreateRadialGradient(Center, Radius, Colors, Positions, SKShaderTileMode.Clamp, localMatrix);
+                var radius = Math.Max( width, height ) * Radius;
+                var center = new SKPoint(width * Center.X, height * Center.Y);
+                return SKShader.CreateRadialGradient(center, radius, Colors, Positions, SKShaderTileMode.Clamp, localMatrix);
             }
 
             return null;

--- a/Topten.RichTextKit/TextGradient.cs
+++ b/Topten.RichTextKit/TextGradient.cs
@@ -51,21 +51,22 @@ namespace Topten.RichTextKit
             startPoint = rotation.MapPoint(startPoint);
             endPoint = rotation.MapPoint(endPoint);
 
-            var sx = Math.Abs(endPoint.X - startPoint.X);
-            var sy = Math.Abs(endPoint.Y - startPoint.Y);
-            if (sx == 0) sx = 1;
-            if (sy == 0) sy = 1;
-
-            sx = width / sx;
-            sy = height / sy;
-
-            var localTranslation = SKMatrix.CreateTranslation(offsetx, 0);
-            var localScale = SKMatrix.CreateScale(sx, sy, width * .5f, height * .5f);
-            var localMatrix = SKMatrix.Concat(localTranslation, localScale);
+            var localMatrix = SKMatrix.CreateTranslation(offsetx, 0);
 
             if (GradientType == GradientType.Linear)
             {
-                return SKShader.CreateLinearGradient( startPoint, endPoint, Colors, Positions, SKShaderTileMode.Decal, localMatrix);
+                var sx = Math.Abs(endPoint.X - startPoint.X);
+                var sy = Math.Abs(endPoint.Y - startPoint.Y);
+                if (sx == 0) sx = 1;
+                if (sy == 0) sy = 1;
+
+                sx = width / sx;
+                sy = height / sy;
+
+                var localScale = SKMatrix.CreateScale(sx, sy, width * .5f, height * .5f);
+                localMatrix = SKMatrix.Concat(localMatrix, localScale);
+
+                return SKShader.CreateLinearGradient( startPoint, endPoint, Colors, Positions, SKShaderTileMode.Clamp, localMatrix);
             }
 
             if(GradientType == GradientType.Radial)

--- a/Topten.RichTextKit/TextGradient.cs
+++ b/Topten.RichTextKit/TextGradient.cs
@@ -1,0 +1,87 @@
+﻿
+using SkiaSharp;
+using System;
+using System.Linq;
+
+namespace Topten.RichTextKit
+{
+    /// <summary>
+    /// Desribes a gradient to apply to the text
+    /// </summary>
+    public class TextGradient
+    {
+
+        public SKPoint Center { get; set; }
+        public float Radius { get; set; }
+        public GradientType GradientType { get; set; }
+        public SKColor[] Colors { get; set; }
+        public float[] Positions { get; set; }
+        public float Angle { get; set; }
+
+        public static TextGradient Linear(SKColor[] colors, float[] positions, float angle)
+        {
+            return new TextGradient()
+            {
+                GradientType = GradientType.Linear,
+                Colors = colors,
+                Positions = positions,
+                Angle = angle
+            };
+        }
+
+        public static TextGradient Radial(SKColor[] colors, float[] positions, float angle, SKPoint center, float radius)
+        {
+            return new TextGradient()
+            {
+                GradientType = GradientType.Radial,
+                Colors = colors,
+                Positions = positions,
+                Angle = angle,
+                Center = center,
+                Radius = radius
+            };
+        }
+
+        internal SKShader CreateShader(float width, float height, float offsetx = 0)
+        {
+            var rotation = SKMatrix.CreateRotationDegrees(180 + Angle, width * .5f, height * .5f);
+            var startPoint = new SKPoint(width * .5f, 0);
+            var endPoint = new SKPoint(width * .5f, height);
+
+            startPoint = rotation.MapPoint(startPoint);
+            endPoint = rotation.MapPoint(endPoint);
+
+            var sx = Math.Abs(endPoint.X - startPoint.X);
+            var sy = Math.Abs(endPoint.Y - startPoint.Y);
+            if (sx == 0) sx = 1;
+            if (sy == 0) sy = 1;
+
+            sx = width / sx;
+            sy = height / sy;
+
+            var localTranslation = SKMatrix.CreateTranslation(offsetx, 0);
+            var localScale = SKMatrix.CreateScale(sx, sy, width * .5f, height * .5f);
+            var localMatrix = SKMatrix.Concat(localTranslation, localScale);
+
+            if (GradientType == GradientType.Linear)
+            {
+                return SKShader.CreateLinearGradient( startPoint, endPoint, Colors, Positions, SKShaderTileMode.Decal, localMatrix);
+            }
+
+            if(GradientType == GradientType.Radial)
+            {
+                return SKShader.CreateRadialGradient(Center, Radius, Colors, Positions, SKShaderTileMode.Clamp, localMatrix);
+            }
+
+            return null;
+        }
+
+    }
+
+    public enum GradientType
+    {
+        Linear,
+        Radial
+    }
+
+}

--- a/Topten.RichTextKit/TextGradient.cs
+++ b/Topten.RichTextKit/TextGradient.cs
@@ -89,26 +89,23 @@ namespace Topten.RichTextKit
                 switch (SizeMode)
                 {
                     case RadialSizeMode.Circle:
-                        scaleX = Math.Min(left, right) / width;
-                        scaleY = Math.Min(top, bottom) / height;
-                        break;
-                    case RadialSizeMode.ClosestSide:
-                        scaleX = Math.Min(left, right) / width;
-                        scaleY = Math.Min(top, bottom) / height;
-                        break;
                     case RadialSizeMode.FarthestSide:
                         scaleX = Math.Max(left, right) / width;
                         scaleY = Math.Max(top, bottom) / height;
-                        break;
-                    case RadialSizeMode.ClosestCorner:
-                        var closestCorner = new SKPoint[] { tl, tr, br, bl }.OrderBy( x => x.Length ).First();
-                        scaleX = closestCorner.X / width;
-                        scaleY = closestCorner.Y / height;
                         break;
                     case RadialSizeMode.FarthestCorner:
                         var furthestCorner = new SKPoint[] { tl, tr, br, bl }.OrderByDescending(x => x.Length).First();
                         scaleX = furthestCorner.X / width;
                         scaleY = furthestCorner.Y / height;
+                        break;
+                    case RadialSizeMode.ClosestSide:
+                        scaleX = Math.Min(left, right) / width;
+                        scaleY = Math.Min(top, bottom) / height;
+                        break;
+                    case RadialSizeMode.ClosestCorner:
+                        var closestCorner = new SKPoint[] { tl, tr, br, bl }.OrderBy( x => x.Length ).First();
+                        scaleX = closestCorner.X / width;
+                        scaleY = closestCorner.Y / height;
                         break;
                 }
 

--- a/Topten.RichTextKit/TextPaintOptions.cs
+++ b/Topten.RichTextKit/TextPaintOptions.cs
@@ -131,6 +131,15 @@ namespace Topten.RichTextKit
         } = SKFontHinting.Normal;
 
         /// <summary>
+        /// A gradient used when rendering text
+        /// </summary>
+        public TextGradient TextGradient
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// A default set of paint options that renders text blocks without 
         /// a selection range.
         /// </summary>


### PR DESCRIPTION
This introduces a TextGradient class that can be assigned into TextPaintOptions to be used when painting text.

![](https://files.facepunch.com/crayz/1b0411b1/Photoshop_jQmqnYnvzz.png)

With shadows, right alignment:

![](https://files.facepunch.com/crayz/1b0411b1/Sandbox_zMNg7p6ZJA.png)

Usage: 

```c#
...

var textGradient = TextGradient.Linear(
	new SKColor[]
	{
		SKColors.DodgerBlue,
		SKColors.Salmon,
		SKColors.GreenYellow
	}, 
	null, 		// optional float array of stopping points
	45 		// angle
);

textPaintOptions.TextGradient = textGradient;

textBlock.Paint(canvas, new SKPoint(margin, margin), textPaintOptions);
```

Todo:

- [x] Implementation will work for us 
- [x] Test/ensure radial gradient
- [ ] ~~Look into whitespace above and below glyphs eating a chunk of the gradient~~
- [ ] ~~Look into cleaning up shader matrix~~